### PR TITLE
Fix for variable function calls don't convert

### DIFF
--- a/packages/transformer/src/visitation.ts
+++ b/packages/transformer/src/visitation.ts
@@ -64,7 +64,7 @@ export function getVisitor(context: ts.TransformationContext, program: ts.Progra
                 const signature: ts.Signature = checker.getResolvedSignature(parent);
                 const declaration = signature.declaration;
 
-                if (ts.isFunctionDeclaration(declaration) || ts.isMethodDeclaration(declaration) || ts.isConstructorDeclaration(declaration))
+                if (ts.isFunctionLike(declaration) || ts.isMethodDeclaration(declaration) || ts.isConstructorDeclaration(declaration))
                 {
                     let param: ts.ParameterDeclaration = declaration.parameters[argIndex];
                     let ignoreThisNode = false;


### PR DESCRIPTION
```typescript
import { Expression } from "tst-expression";

function FnWhere<T>(predicate: Expression<(m: T) => boolean>) {

}

const VarWhere=<T>(predicate: Expression<(m: T) => boolean>) =>{

}

interface Blog {
	Id: number
	Title: string
}

FnWhere<Blog>(b => b.Id == 1 )
//Fix the line don't convert
VarWhere<Blog>(b => b.Id == 2 )
```

Hello @Hookyns.
This new version is good, but there are some problems, and I'm not sure if this change has any other impact.。